### PR TITLE
CVE-2020-16010: fix function name in title

### DIFF
--- a/0day-RCAs/2020/CVE-2020-16010.md
+++ b/0day-RCAs/2020/CVE-2020-16010.md
@@ -1,4 +1,4 @@
-# CVE-2020-16010: Chrome for Android ConverToJavaBitmap Heap Buffer Overflow
+# CVE-2020-16010: Chrome for Android ConvertToJavaBitmap Heap Buffer Overflow
 *Mark Brand and Sergei Glazunov, Project Zero (Originally posted on [Project Zero blog](https://googleprojectzero.blogspot.com/p/rca.html) 2021-02-04)*
 
 ## The Basics


### PR DESCRIPTION
The vulnerability details showed the correct function name, but the title was missing a letter.