### PR TITLE
Correct broken link

### DIFF
--- a/0day-RCAs/2020/CVE-2020-6418.md
+++ b/0day-RCAs/2020/CVE-2020-6418.md
@@ -116,4 +116,4 @@ These types of exploits are likely hard to detect generically.
 ## Other References 
 
 * January 2021: [“In The Wild: Chrome exploits”](https://googleprojectzero.blogspot.com/2021/01/in-wild-series-chrome-exploits.html) blogpost
-* May 2019: ["Exploiting Logic Bugs in JavaScript JIT Engines"](http://www.phrack.org/papers/jit_exploitation.html) by @saelo
+* May 2019: ["Exploiting Logic Bugs in JavaScript JIT Engines"](http://www.phrack.org/issues/70/9.html#article) by @saelo


### PR DESCRIPTION
I noticed that a link to the phrack magazine paper "Exploiting Logic Bugs in JavaScript JIT Engines" is broken. This should correct the link. Thanks.